### PR TITLE
Deep merge hashes for *-sites merge with site config.

### DIFF
--- a/libraries/util.rb
+++ b/libraries/util.rb
@@ -1,0 +1,12 @@
+module ConfigDrivenHelper
+  module Util
+    def immutablemash_to_hash(immutable_mash)
+      result = immutable_mash.to_hash.dup
+      result.each_pair do |key, value|
+        if value.is_a?(Chef::Node::ImmutableMash)
+          result[key] = immutablemash_to_hash(value)
+        end
+      end
+    end
+  end
+end

--- a/recipes/apache-sites.rb
+++ b/recipes/apache-sites.rb
@@ -1,6 +1,10 @@
 if node["apache"] && node["apache"]["sites"]
+  ::Chef::Recipe.send(:include, ConfigDrivenHelper::Util)
+
   node["apache"]["sites"].each do |name, site|
-    site = node["apache-sites"].merge(site)
+    site = ::Chef::Mixin::DeepMerge.hash_only_merge(
+      immutablemash_to_hash(node["apache-sites"]),
+      immutablemash_to_hash(site))
 
     [site['protocols']].flatten.each do |current_protocol|
       next unless ['http', 'https'].include? current_protocol

--- a/recipes/nginx-sites.rb
+++ b/recipes/nginx-sites.rb
@@ -1,7 +1,10 @@
 if node["nginx"] && node["nginx"]["sites"]
+  ::Chef::Recipe.send(:include, ConfigDrivenHelper::Util)
+
   node["nginx"]["sites"].each do |name, site|
-    site = node["nginx-sites"]
-      .merge(site)
+    site = ::Chef::Mixin::DeepMerge.hash_only_merge(
+      immutablemash_to_hash(node["nginx-sites"]),
+      immutablemash_to_hash(site))
 
     site['server_name'] = name if !site['server_name']
     name = site['server_name']


### PR DESCRIPTION
Hash.merge doesn't recursively merge, and so causes
'*-sites' -> 'ssl' -> {..} to be lost on merge.

A function to copy the node ImmutableMash attributes
to hashes was needed in order to get around the
immutability issue.
