### PR TITLE
Forces mysql-ruby to install mysql gem in to chef-omnibus ruby

### DIFF
--- a/recipes/mysql-ruby.rb
+++ b/recipes/mysql-ruby.rb
@@ -2,6 +2,6 @@ include_recipe 'mysql::client'
 include_recipe 'build-essential'
 
 gem_package "mysql" do
-  gem_binary nil
+  gem_binary File.join(RbConfig::CONFIG["bindir"], 'gem')
   action :install
 end


### PR DESCRIPTION
`gem_package nil` doesn't appear to have the desired effect (installing the mysql gem in to the omnibus ruby), at least with the (as yet unpublished) 0.1.4 boxes.

Being explicit about it, that is to say specifying the gem binary directly instead of relying on `nil` to default to it seems to work.

RbConfig is used to get the bindir of the current ruby which is assumed to be the same as that of the gem command (which is generally true I believe).

There may be cases that this assertion does not hold but I believe that these should be few and far between on sensible configurations.
