### PR TITLE
Drops localhost server_name for nginx because it doesn't make sense

### DIFF
--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -22,7 +22,7 @@ server {
         <% end %>
     <% end %>
 
-    server_name <%= [ 'localhost', @params['server_name'] ].concat(@params['server_aliases'] ? @params['server_aliases'] : []).join(" ")%>;
+    server_name <%= [ @params['server_name'] ].concat(@params['server_aliases'] ? @params['server_aliases'] : []).join(" ")%>;
 
     location / {
         <% if @params['endpoint'] and not @params['endpoint'].empty? %>


### PR DESCRIPTION
Pointed out by @andytson, all vhosts having server_name of localhost could behave weird and it messes with the SERVER_NAME var passed on to PHP.

It can easily be added back in a more sensible place in the list by using server_aliases
