### PR TITLE
TMUP-373: Add realpath_root instead of document_root as a flag.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,7 @@ protocols = {
     site['insecure_port'] = 80
     site['endpoint'] = 'index.php'
     site['php_support'] = true
+    site['realpath_document_root'] = false
     site['php-fpm']['host'] = '127.0.0.1'
     site['php-fpm']['port'] = 9000
     site['php-fpm']['socket'] = '/var/run/php-fpm-www.sock'

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -45,7 +45,11 @@ server {
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
 
+        <% if @params['realpath_document_root'] %>
+        fastcgi_param PATH_TRANSLATED $realpath_root$fastcgi_path_info;
+        <% else %>
         fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
+        <% end %>
         fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param HTTPS $https;


### PR DESCRIPTION
ZendOpcache has problems caching entries based on the symlink.
This stops PHP via Nginx receiving the symlink and caching php files that change
between deployments.

It doesn't resolve Apache httpd, which instead will be dealt with using mod_realdoc
on the basebox/seeds
