### PR TITLE
Pin nginx and apache cookbook versions

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 #^syntax detection
 source 'https://api.berkshelf.com'
-cookbook 'nginx'
-cookbook 'apache2'
+cookbook 'nginx', '~> 2.4.2'
+cookbook 'apache2', '~> 1.11.0'
 cookbook 'php-fpm'
 cookbook 'mysql'
 cookbook 'config-driven-helper', :path => '.'


### PR DESCRIPTION
Is this the correct way to pin versions, and are they the right versions? 
