### PR TITLE
Add the ability for PHP $_SERVER variables to be set in apache and nginx sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,28 @@ You can override any of these values by simply defining them in your site attrib
 
 It is assumed that projects that use this cookbook also use the data-bag-merge cookbook from https://cookbooks.opscode.com/cookbooks/data-bag-merge. This cookbook merges encrypted data bags in to your chef attributes to enabled encrypted attributes for cookbooks that do not directly support them.
 
+### Server params 
+
+To add fastcgi_param for Nginx or SetEnv for Apache use php_server_variables under sites key, like in this example for apache (it's similiar for nginx):
+
+```json
+{
+  'apache': {
+    'sites': {
+      'inviqa': {
+        'server_name': 'inviqa.com',
+        'docroot': '/var/www/inviqa.com',
+        'protocols': [ 'http', 'https' ],
+        "php_server_variables": {
+          "FOO": "bar",
+          "ANOTHER": "value"
+        }
+      }
+    }
+  }
+}
+```
+
 ## Nginx sites
 
 The nginx sites helper is very similar to the apache sites helper with the exception that it does not proxy to any kind of `web_app` helper and uses the `nginx` top level attribute instead.

--- a/templates/default/apache_site.conf.erb
+++ b/templates/default/apache_site.conf.erb
@@ -51,6 +51,10 @@
 
     DirectoryIndex index.php
 
+    <% (@params['php_server_variables'] || []).each do |header, value| %>
+    SetEnv <%= header %> <%= value %>
+    <% end %>
+
     <IfModule mod_security.c>
         ###########################################
         # disable POST processing to not break multiple image upload

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -56,6 +56,10 @@ server {
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param HTTPS $https;
 
+        <% (@params['php_server_variables'] || []).each do |header, value| %>
+        fastcgi_param <%= header %> <%= value %>;
+        <% end %>
+
         fastcgi_pass <%= @params['php-fpm']['listen'] == "socket" ? "unix:#{@params['php-fpm']['socket']}" : "#{@params['php-fpm']['host']}:#{@params['php-fpm']['port']}" %>;
     }
     <% end %>


### PR DESCRIPTION
$_SERVER pulls in amongst other things, apache environmental variables, and fastcgi headers