### PR TITLE
Force location search stopping at restricted_dirs locations if matched.

### DIFF
--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -26,6 +26,10 @@ server {
 
     server_name <%= [ @params['server_name'] ].concat(@params['server_aliases'] ? @params['server_aliases'] : []).join(" ")%>;
 
+    <% (@params['restricted_dirs'] || []).each do |dir| %>
+    location ^~ <%= dir %> { deny all; }
+    <% end %>
+
     <% unless @params['disable_default_location_block'] %>
     location / {
         <% if @params['endpoint'] and not @params['endpoint'].empty? %>
@@ -66,10 +70,6 @@ server {
 
     error_log /var/log/nginx/<%= @params['server_name'] %>_error.log;
     access_log /var/log/nginx/<%= @params['server_name'] %>_access.log;
-
-    <% (@params['restricted_dirs'] || []).each do |dir| %>
-    location <%= dir %> { deny all; }
-    <% end %>
 
     <% (@params['includes'] || []).each do |file| %>
     include <%= file %>;


### PR DESCRIPTION
Other location blocks would match subpaths of the restricted
directories if higher precedence.

e.g. the current location ~ \.php block, which would allow
PHP files to be executed underneath those restricted
directories.