### PR TITLE
Add static_dirs site configuration to disable PHP handling

### DIFF
--- a/templates/default/apache_site.conf.erb
+++ b/templates/default/apache_site.conf.erb
@@ -165,6 +165,12 @@
   </Directory>
   <% end %>
 
+  <% (@params['static_dirs'] || []).each do |dir| %>
+  <Directory <%= @params['docroot'] %>/<%= dir %>>
+      SetHandler None
+  </Directory>
+  <% end %>
+
   # Include any additional configuration for the project
   <%= (@params['includes'] || []).map{ |i| "Include #{i}" }.join("\n  ") %>
 </VirtualHost>

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -30,6 +30,10 @@ server {
     location ^~ <%= dir %> { deny all; }
     <% end %>
 
+    <% (@params['static_dirs'] || []).each do |dir| %>
+    location ^~ <%= dir %> { }
+    <% end %>
+
     <% unless @params['disable_default_location_block'] %>
     location / {
         <% if @params['endpoint'] and not @params['endpoint'].empty? %>

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -26,6 +26,10 @@ server {
 
     server_name <%= [ @params['server_name'] ].concat(@params['server_aliases'] ? @params['server_aliases'] : []).join(" ")%>;
 
+    <% (@params['restricted_dirs'] || []).each do |dir| %>
+    location ^~ <%= dir %> { deny all; }
+    <% end %>
+
     <% unless @params['disable_default_location_block'] %>
     location / {
         <% if @params['endpoint'] and not @params['endpoint'].empty? %>
@@ -66,10 +70,6 @@ server {
 
     error_log /var/log/nginx/<%= @params['server_name'] %>_error.log;
     access_log /var/log/nginx/<%= @params['server_name'] %>_access.log;
-
-    <% (@params['restricted_dirs'] || []).each do |dir| %>
-    location <%= dir %> { deny all; }
-    <% end %>
 
     <% (@params['includes'] || []).each do |file| %>
     include <%= file %>;


### PR DESCRIPTION
A site can then define static_dirs that don't get passed to PHP
and instead by default get treated as static files even
if 404ing.

It also means code can't be maliciously uploaded and executed.