### PR TITLE
Fix issue where definition recipe was merged instead of site

### DIFF
--- a/definitions/app_vhost.rb
+++ b/definitions/app_vhost.rb
@@ -52,5 +52,5 @@ define :app_vhost, :server_type => nil, :site => {} do
     end
   end
 
-  site
+  params[:site] = site
 end

--- a/recipes/apache-sites.rb
+++ b/recipes/apache-sites.rb
@@ -1,7 +1,7 @@
 node["apache"]["sites"].each do |name, site_attrs|
-  site = app_vhost name do
+  definition = app_vhost name do
     site site_attrs
     server_type 'apache'
   end
-  ::Chef::Mixin::DeepMerge.hash_only_merge!(node.force_override['apache']['sites'][name], site)
+  ::Chef::Mixin::DeepMerge.hash_only_merge!(node.force_override['apache']['sites'][name], definition.params[:site])
 end

--- a/recipes/nginx-sites.rb
+++ b/recipes/nginx-sites.rb
@@ -2,9 +2,9 @@ include_recipe 'config-driven-helper::nginx-compat-disable-default'
 include_recipe 'config-driven-helper::nginx-compat-https-map-emulation'
 
 node["nginx"]["sites"].each do |name, site_attrs|
-  site = app_vhost name do
+  definition = app_vhost name do
     site site_attrs
     server_type 'nginx'
   end
-  ::Chef::Mixin::DeepMerge.hash_only_merge!(node.force_override['nginx']['sites'][name], site)
+  ::Chef::Mixin::DeepMerge.hash_only_merge!(node.force_override['nginx']['sites'][name], definition.params[:site])
 end


### PR DESCRIPTION
A call to a definition returns a recipe object rather than
the return value of the definition.