### PR TITLE
Update capistrano_site definition to create deploy_to folder recursively

### DIFF
--- a/definitions/capistrano_app.rb
+++ b/definitions/capistrano_app.rb
@@ -9,6 +9,7 @@ define :capistrano_app, :deploy_to => nil do
   directory params[:deploy_to] do
     owner params[:owner]
     group params[:group]
+    recursive true
   end
 
   %w( shared releases ).each do |folder|


### PR DESCRIPTION
There are cases where the parents of the deploy_to directory
don't exist. Recursively creating them (which would set the
parents as root:root if not existing) should resolve this.

If the parents already exist, their ownership wont change.