### PR TITLE
Fix the location of Apache Httpd log files

### DIFF
--- a/templates/default/apache_site.conf.erb
+++ b/templates/default/apache_site.conf.erb
@@ -19,8 +19,8 @@
   DocumentRoot <%= @params['docroot'] %>
 
   LogLevel info
-  ErrorLog <%= @params['server_name'] %>-error.log
-  CustomLog <%= @params['server_name'] %>-access.log combined
+  ErrorLog logs/<%= @params['server_name'] %>-error.log
+  CustomLog logs/<%= @params['server_name'] %>-access.log combined
 
   ServerSignature Off
 


### PR DESCRIPTION
/etc/httpd/logs is a symlink to /var/log/httpd (also the same idea used on ubuntu for /etc/apache2/logs)

Convention is to use this directory to store log files.
A separate PR can be done at some point to allow configuration