### PR TITLE
Add kitchen coverage for multiple chef versions

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,11 +7,29 @@ driver:
 
 provisioner:
   name: chef_solo
-  require_chef_omnibus: 11.10.4
   chef_omnibus_install_options: -d /tmp/vagrant-cache/vagrant_omnibus
 
 platforms:
-  - name: centos-6.6
+  - name: centos-6.6-chef-11.10
+    driver:
+      box: opscode-centos-6.6
+    provisioner:
+      require_chef_omnibus: "11.10"
+  - name: centos-6.6-chef-11.18
+    driver:
+      box: opscode-centos-6.6
+    provisioner:
+      require_chef_omnibus: "11.18"
+  - name: centos-6.6-chef-12.0
+    driver:
+      box: opscode-centos-6.6
+    provisioner:
+      require_chef_omnibus: "12.0"
+  - name: centos-6.6-chef-12.4
+    driver:
+      box: opscode-centos-6.6
+    provisioner:
+      require_chef_omnibus: "12.4"
 
 suites:
   - name: services

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,6 +7,8 @@ driver:
 
 provisioner:
   name: chef_solo
+  require_chef_omnibus: 11.10.4
+  chef_omnibus_install_options: -d /tmp/vagrant-cache/vagrant_omnibus
 
 platforms:
   - name: centos-6.6

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -42,6 +42,7 @@ suites:
         server_debian_password: password
         server_root_password: password
         server_repl_password: password
+        bind_address: 127.0.0.1
       services:
         nginx:
           - disable
@@ -71,6 +72,7 @@ suites:
         server_debian_password: password
         server_root_password: password
         server_repl_password: password
+        bind_address: 127.0.0.1
 
   - name: nginx-sites-ssl
     run_list:
@@ -97,6 +99,7 @@ suites:
         server_debian_password: password
         server_root_password: password
         server_repl_password: password
+        bind_address: 127.0.0.1
 
   - name: nginx-sites-advanced
     run_list:
@@ -126,3 +129,4 @@ suites:
         server_debian_password: password
         server_root_password: password
         server_repl_password: password
+        bind_address: 127.0.0.1

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,9 @@
 ---
 driver:
   name: vagrant
+  vagrantfiles:
+    - ./test/.Vagrantfile.cachier.rb
+    - ./test/.Vagrantfile.disable-berkshelf.rb
 
 provisioner:
   name: chef_solo

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
 source 'https://supermarket.chef.io'
 
 metadata
+
+cookbook 'nginx', '> 2.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 group :integration do
   gem 'berkshelf', '~> 3.2.3'
-  gem 'kitchen-vagrant', '~> 0.15.0'
+  gem 'kitchen-vagrant', '~> 0.16.0'
   gem 'test-kitchen', '~> 1.3.1'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
     hitimes (1.2.2)
     ipaddress (0.8.0)
     json (1.8.2)
-    kitchen-vagrant (0.15.0)
+    kitchen-vagrant (0.16.0)
       test-kitchen (~> 1.0)
     libyajl2 (1.2.0)
     method_source (0.8.2)
@@ -113,7 +113,7 @@ GEM
     mixlib-cli (1.5.0)
     mixlib-config (2.1.0)
     mixlib-log (1.6.0)
-    mixlib-shellout (2.0.1)
+    mixlib-shellout (2.1.0)
     multi_json (1.11.0)
     multipart-post (2.0.0)
     net-dhcp (1.3.2)
@@ -245,7 +245,10 @@ DEPENDENCIES
   berkshelf (~> 3.2.3)
   chefspec (~> 4.2.0)
   foodcritic (~> 4.0)
-  kitchen-vagrant (~> 0.15.0)
+  kitchen-vagrant (~> 0.16.0)
   rake (~> 10.1)
   rubocop (~> 0.29.1)
   test-kitchen (~> 1.3.1)
+
+BUNDLED WITH
+   1.10.3

--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,99 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml
+
+# Kitchen #
+###########
+.kitchen

--- a/chefignore
+++ b/chefignore
@@ -97,3 +97,4 @@ Vagrantfile
 # Kitchen #
 ###########
 .kitchen
+.Vagrantfile*

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ version           "1.4.0"
 depends "apache2", "~> 1.8"
 depends 'iptables-ng', '~> 2.2.0'
 depends "mysql", "~> 4.0"
-depends 'nginx', '< 2.5'
+depends 'nginx', '< 2.4.4'
 depends 'chef-solo-search', '~> 0.5.1'
 depends "database", "~> 2.0"
 depends "build-essential", "~> 1.4"

--- a/test/.Vagrantfile.cachier.rb
+++ b/test/.Vagrantfile.cachier.rb
@@ -1,0 +1,42 @@
+Vagrant.configure('2') do |config|
+  # The following configuration supports shared folders with host
+  # aware configuration of NFS for performance benefits on unix based hosts
+  require 'ffi'
+  use_nfs = !FFI::Platform::IS_WINDOWS && ::File.exist?('/etc/sudoers.d/vagrant_nfs')
+  has_cachier = Vagrant.has_plugin?('vagrant-cachier')
+
+  config.vm.network 'private_network', type: 'dhcp'
+
+
+  # Enable Vagrant Cachier, for speedy destroy/creates
+  if has_cachier
+    # Configure cached packages to be shared between instances of the same base box.
+    # More info on http://fgrehm.viewdocs.io/vagrant-cachier/usage
+    config.cache.scope = :box
+
+    if use_nfs
+      # OPTIONAL: If you are using VirtualBox, you might want to use that to enable
+      # NFS for shared folders. This is also very useful for vagrant-libvirt if you
+      # want bi-directional sync
+      config.cache.synced_folder_opts = {
+        type: :nfs,
+        # The nolock option can be useful for an NFSv3 client that wants to avoid the
+        # NLM sideband protocol. Without this option, apt-get might hang if it tries
+        # to lock files needed for /var/cache/* operations. All of this can be avoided
+        # by using NFSv4 everywhere. Please note that the tcp option is not the default.
+        mount_options: ['rw', 'vers=3', 'tcp', 'nolock']
+      }
+    end
+
+    config.cache.enable :chef
+    config.cache.enable :yum
+    config.cache.enable :gem
+  end
+
+  config.vm.provision :chef_solo do |chef|
+    chef.file_cache_path = chef.provisioning_path unless has_cachier
+
+    # Mount chef folders via NFS for speed
+    chef.synced_folder_type = 'nfs' if use_nfs
+  end
+end

--- a/test/.Vagrantfile.cachier.rb
+++ b/test/.Vagrantfile.cachier.rb
@@ -7,7 +7,6 @@ Vagrant.configure('2') do |config|
 
   config.vm.network 'private_network', type: 'dhcp'
 
-
   # Enable Vagrant Cachier, for speedy destroy/creates
   if has_cachier
     # Configure cached packages to be shared between instances of the same base box.

--- a/test/.Vagrantfile.disable-berkshelf.rb
+++ b/test/.Vagrantfile.disable-berkshelf.rb
@@ -1,5 +1,3 @@
 Vagrant.configure('2') do |config|
-  if Vagrant.has_plugin?('vagrant-berkshelf') then
-    config.berkshelf.enabled = false
-  end
+  config.berkshelf.enabled = false if Vagrant.has_plugin?('vagrant-berkshelf')
 end

--- a/test/.Vagrantfile.disable-berkshelf.rb
+++ b/test/.Vagrantfile.disable-berkshelf.rb
@@ -1,0 +1,5 @@
+Vagrant.configure('2') do |config|
+  if Vagrant.has_plugin?("vagrant-berkshelf") then
+    config.berkshelf.enabled = false
+  end
+end

--- a/test/.Vagrantfile.disable-berkshelf.rb
+++ b/test/.Vagrantfile.disable-berkshelf.rb
@@ -1,5 +1,5 @@
 Vagrant.configure('2') do |config|
-  if Vagrant.has_plugin?("vagrant-berkshelf") then
+  if Vagrant.has_plugin?('vagrant-berkshelf') then
     config.berkshelf.enabled = false
   end
 end


### PR DESCRIPTION
- Upgrade kitchen-vagrant to support the "vagrantfiles" configuration section
- Add vagrant-cachier configuration and NFS configuration
- Converge with multiple chef versions (11.10.x, 11.18.x, 12.0.x, 12.4.x)
- Add bind_address for the mysql cookbook to converge successfully in 11.18.x, where the bind_address in `/etc/my.cnf` is `[]` for some reason.
- Downgrade nginx to v2.4.4 after discussion with Andy
- Ensure nginx > 2.0.0 is picked by berkshelf so the kitchen converge works.