### PR TITLE
Use configured user data bag name consistantly

### DIFF
--- a/recipes/capistrano.rb
+++ b/recipes/capistrano.rb
@@ -15,8 +15,9 @@ group node['capistrano']['group'] do
   gid if node['capistrano']['gid']
 end if node['capistrano']['group']
 
-data_bag(node['capistrano']['user_data_bag']).each do |bag_item_id|
-  u = Chef::EncryptedDataBagItem.load('users', bag_item_id)
+user_data_bag = node['capistrano']['user_data_bag']
+data_bag(user_data_bag).each do |bag_item_id|
+  u = Chef::EncryptedDataBagItem.load(user_data_bag, bag_item_id)
   u['username'] ||= u['id']
 
   next unless u['groups'].include? node['capistrano']['group']


### PR DESCRIPTION
Allowing the user data bag name to be configured makes it easier to use multiple encryption keys in a single project. That attribute is currently not being used for opening the data bags.