### PR TITLE
Fix nginx cookbook version selection.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -3,3 +3,10 @@ source 'https://supermarket.chef.io'
 metadata
 
 cookbook 'nginx', '> 2.0', '< 2.4.4'
+
+group :integration do
+  cookbook 'aws', '< 2.9.0'
+  cookbook 'iptables', '~> 1.0'
+  cookbook 'ohai', '~> 1.1'
+  cookbook 'yum', '>= 3.0'
+end

--- a/Berksfile
+++ b/Berksfile
@@ -4,9 +4,16 @@ metadata
 
 cookbook 'nginx', '> 2.0', '< 2.4.4'
 
-group :integration do
-  cookbook 'aws', '< 2.9.0'
-  cookbook 'iptables', '~> 1.0'
-  cookbook 'ohai', '~> 1.1'
-  cookbook 'yum', '>= 3.0'
-end
+# Force aws cookbook to not require ohai 2.1.0+, which is incompatible with
+# nginx 2.4.x
+cookbook 'aws', '< 2.9.0'
+
+# Force iptables to 1.x, as 2.x brings in compat_resource, which is incompatible
+# with chef 11.x
+cookbook 'iptables', '~> 1.0'
+
+# Make doubly sure that ohai 1.1.x is used instead of 2.1.0+
+cookbook 'ohai', '~> 1.1'
+
+# Ensure yum::epel is not required by nginx by forcing a requirement for 3.x
+cookbook 'yum', '>= 3.0'


### PR DESCRIPTION
Issue: `berks` chose nginx 1.8.0 which fails due to yum 2.x being used.
This was caused by aws cookbook releasing v2.9.0 which increased the
ohai version to be 2.1.0+.
The database cookbook requires any version of the aws cookbook.
The nginx cookbook requires '~> 1.1' of ohai so berkshelf picks the
best version that uses any version of ohai, 1.8.0.

The iptables v2 cookbook brings in compat_resource, which isn't compatible with chef 11.