### PR TITLE
Capistrano recipe Chef 12 fix

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -29,7 +29,7 @@ platforms:
     driver:
       box: bento/centos-6.7
     provisioner:
-      require_chef_omnibus: "12.4"
+      require_chef_omnibus: "12.8"
 
 suites:
   - name: services

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -109,16 +109,37 @@ suites:
       - recipe[php-fpm]
       - recipe[nginx-test::docroot]
       - recipe[config-driven-helper::nginx-sites]
+      - recipe[config-driven-helper::capistrano]
     attributes:
+      capistrano:
+        user_data_bag: false
       php-fpm:
         user: nginx
         group: nginx
       nginx:
+        shared_config:
+          my-app:
+            capistrano:
+              owner: root
+              group: nobody
+              shared_folders:
+                readable:
+                  folders:
+                    - readable1
+                    - readable2
+                writeable:
+                  owner: nobody
+                  folders:
+                    - writeable1
+                    - readable2/./writeable2
         sites:
           site1:
+            inherits: my-app
             server_name: "test.dev"
             server_aliases: [ "test1.dev", "test2.dev" ]
             docroot: "/docroot"
+            capistrano:
+              deploy_to: /var/www/test.dev
             server_params: 
               "set $php_value": "\"cgi.fix_pathinfo = 0\""
             includes:

--- a/recipes/apache-sites.rb
+++ b/recipes/apache-sites.rb
@@ -12,7 +12,11 @@ node['apache']['sites'].each do |name, site_attrs|
   end
 
   begin
-    values = node.attribute.combined_override['apache']['sites'][name]
+    begin
+      values = node.attribute.combined_override['apache']['sites'][name]
+    rescue
+      values = {}
+    end
     ::Chef::Mixin::DeepMerge.hash_only_merge!(values, site)
     node.force_override!['apache']['sites'][name] = values
   rescue

--- a/recipes/apache-sites.rb
+++ b/recipes/apache-sites.rb
@@ -18,7 +18,7 @@ node['apache']['sites'].each do |name, site_attrs|
       values = {}
     end
     ::Chef::Mixin::DeepMerge.hash_only_merge!(values, site)
-    node.force_override!['apache']['sites'][name] = values
+    node.force_override!(autovivify: false)['apache']['sites'][name] = values
   rescue
     # Chef 11.10 compat
     ::Chef::Mixin::DeepMerge.hash_only_merge!(node.force_override['apache']['sites'][name], site)

--- a/recipes/nginx-sites.rb
+++ b/recipes/nginx-sites.rb
@@ -15,7 +15,11 @@ node['nginx']['sites'].each do |name, site_attrs|
   end
 
   begin
-    values = node.attribute.combined_override['nginx']['sites'][name]
+    begin
+      values = node.attribute.combined_override['nginx']['sites'][name]
+    rescue
+      values = {}
+    end
     ::Chef::Mixin::DeepMerge.hash_only_merge!(values, site)
     node.force_override!['nginx']['sites'][name] = values
   rescue

--- a/recipes/nginx-sites.rb
+++ b/recipes/nginx-sites.rb
@@ -21,7 +21,7 @@ node['nginx']['sites'].each do |name, site_attrs|
       values = {}
     end
     ::Chef::Mixin::DeepMerge.hash_only_merge!(values, site)
-    node.force_override!['nginx']['sites'][name] = values
+    node.force_override!(autovivify: false)['nginx']['sites'][name] = values
   rescue
     # Chef 11.10 compat
     ::Chef::Mixin::DeepMerge.hash_only_merge!(node.force_override['nginx']['sites'][name], site)

--- a/test/Berksfile
+++ b/test/Berksfile
@@ -5,3 +5,20 @@ cookbook 'php-fpm'
 cookbook 'nginx', '> 2.0', '< 2.4.4'
 cookbook 'config-driven-helper', :path => '../'
 cookbook 'nginx-test', :path => './cookbooks/nginx-test'
+
+
+# Force aws cookbook to not require ohai 2.1.0+, which is incompatible with
+# nginx 2.4.x
+cookbook 'aws', '< 2.9.0'
+
+# Force iptables to 1.x, as 2.x brings in compat_resource, which is incompatible
+# with chef 11.x
+cookbook 'iptables', '~> 1.0'
+
+# Make doubly sure that ohai 1.1.x is used instead of 2.1.0+
+cookbook 'ohai', '~> 1.1'
+
+cookbook 'rsyslog', '~> 2.2.0'
+
+# Ensure yum::epel is not required by nginx by forcing a requirement for 3.x
+cookbook 'yum', '>= 3.0'

--- a/test/integration/nginx-sites-advanced/serverspec/capistrano_spec.rb
+++ b/test/integration/nginx-sites-advanced/serverspec/capistrano_spec.rb
@@ -1,0 +1,44 @@
+require 'serverspec'
+require 'net/http'
+
+set :backend, :exec
+set :path, '/sbin:/usr/local/sbin:$PATH'
+
+RSpec.configure do |c|
+  c.before :all do
+    c.path = '/sbin:/usr/sbin'
+  end
+end
+
+describe "Capistrano configuration" do
+  it "should create a capistrano application folder structure" do
+    expect(file('/var/www/test.dev')).to be_owned_by 'root'
+    expect(file('/var/www/test.dev')).to be_grouped_into 'nobody'
+    expect(file('/var/www/test.dev')).to be_directory
+
+    expect(file('/var/www/test.dev/shared')).to be_grouped_into 'nobody'
+    expect(file('/var/www/test.dev/shared')).to be_directory
+    expect(file('/var/www/test.dev/releases')).to be_directory
+  end
+
+  it "should create a readable shared folder structure" do
+    expect(file('/var/www/test.dev/shared/readable1')).to be_directory
+    expect(file('/var/www/test.dev/shared/readable1')).to be_owned_by 'root'
+    expect(file('/var/www/test.dev/shared/readable1')).to be_grouped_into 'nobody'
+
+    expect(file('/var/www/test.dev/shared/readable2')).to be_directory
+    expect(file('/var/www/test.dev/shared/readable2')).to be_owned_by 'root'
+    expect(file('/var/www/test.dev/shared/readable2')).to be_grouped_into 'nobody'
+  end
+
+  it "should create a writeable shared folder structure" do
+    expect(file('/var/www/test.dev/shared/writeable1')).to be_directory
+    expect(file('/var/www/test.dev/shared/writeable1')).to be_owned_by 'nobody'
+    expect(file('/var/www/test.dev/shared/writeable1')).to be_grouped_into 'nobody'
+
+    expect(file('/var/www/test.dev/shared/readable2/writeable2')).to be_directory
+    expect(file('/var/www/test.dev/shared/readable2/writeable2')).to be_owned_by 'nobody'
+    expect(file('/var/www/test.dev/shared/readable2/writeable2')).to be_grouped_into 'nobody'
+  end
+
+end


### PR DESCRIPTION
The force_override! wasn't resetting a cache, causing node attribute access to not include it's changes.