### PR TITLE
Roll back the autovivify:false fix

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -25,7 +25,7 @@ platforms:
       box: bento/centos-6.7
     provisioner:
       require_chef_omnibus: "12.0"
-  - name: centos-6-chef-12.4
+  - name: centos-6-chef-12.8
     driver:
       box: bento/centos-6.7
     provisioner:

--- a/recipes/nginx-sites.rb
+++ b/recipes/nginx-sites.rb
@@ -21,7 +21,7 @@ node['nginx']['sites'].each do |name, site_attrs|
       values = {}
     end
     ::Chef::Mixin::DeepMerge.hash_only_merge!(values, site)
-    node.force_override!(autovivify: false)['nginx']['sites'][name] = values
+    node.force_override!['nginx']['sites'][name] = values
   rescue
     # Chef 11.10 compat
     ::Chef::Mixin::DeepMerge.hash_only_merge!(node.force_override['nginx']['sites'][name], site)


### PR DESCRIPTION
It was the other fix from the previous PR that was the actual fix, so this change unnecissary, and might lead to hash/mash difference issues in the future