### PR TITLE
Disable nginx https variable emulation by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 
   * #56 Loosen cookbook constraints to support httpd 2.4
+  * #57 Disable nginx https variable emulation by default
 
 ## 1.5.0 (10 November 2015)
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,7 @@ default['apache']['sites'] = {}
 
 default['ssl_certs'] = {}
 
-default['nginx']['https_variable_emulation'] = true
+default['nginx']['https_variable_emulation'] = false
 
 protocols = {
   'nginx' => 'TLSv1 TLSv1.1 TLSv1.2',


### PR DESCRIPTION
Nginx > 1.2 now in use, which has this. Upgrading projects should enable it if sticking with Nginx 1.0