### PR TITLE
Delete any allowed_incoming_ports marked false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.3 (23 May 2016)
+
+BUG FIXES:
+
+  * #60 Delete any allowed_incoming_ports marked false
+
 ## 2.0.2 (06 May 2016)
 
 IMPROVEMENTS:

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ issues_url        "https://github.com/inviqa/chef-config-driven-helper/issues"
 source_url        "https://github.com/inviqa/chef-config-driven-helper"
 license           "Apache 2.0"
 description       "enable driving cookbooks that are not normally config driven to be so"
-version           "2.0.2"
+version           "2.0.3"
 
 depends "apache2", ">= 1.8"
 depends 'iptables-ng', '>= 2.2'

--- a/recipes/iptables-standard.rb
+++ b/recipes/iptables-standard.rb
@@ -18,11 +18,13 @@ iptables_ng_rule '10-icmp' do
 end
 
 node['iptables-standard']['allowed_incoming_ports'].each do |rule, port|
-  next unless port
-
   iptables_ng_rule "20-#{rule}" do
     chain 'STANDARD-FIREWALL'
-    rule "--protocol tcp --dport #{port} --jump ACCEPT"
+    if port
+      rule "--protocol tcp --dport #{port} --jump ACCEPT"
+    else
+      action :delete
+    end
   end
 end
 

--- a/spec/recipes/iptables-standard_spec.rb
+++ b/spec/recipes/iptables-standard_spec.rb
@@ -77,8 +77,8 @@ describe 'config-driven-helper::iptables-standard' do
       end
     end
 
-    it "doesn't create unmapped rules" do
-      expect(chef_run).not_to create_iptables_ng_rule("20-https")
+    it "deletes unmapped rules" do
+      expect(chef_run).to delete_iptables_ng_rule("20-https")
     end
   end
 end


### PR DESCRIPTION
If the rule was previously applied to a server which then needed disabling, the rule needs deleting.