### PR TITLE
Fix apache 2.4 compatibility

### DIFF
--- a/definitions/app_vhost.rb
+++ b/definitions/app_vhost.rb
@@ -21,6 +21,7 @@ define :app_vhost, :server_type => nil, :site => {} do
 
     service_name = type == 'nginx' ? type : 'apache2'
     name = protocol == 'https' ? "#{params[:name]}.ssl" : params[:name]
+    name = "#{name}.conf" if type == 'apache' && node[type]['version'] == '2.4'
 
     template "#{node[type]['dir']}/sites-available/#{name}" do
       source site["template"]


### PR DESCRIPTION
Apache 2.4 as configured by https://supermarket.chef.io/cookbooks/apache2 requires files to be named `.conf` in sites-available, for the `a2ensite` script to work correctly.

Specifically due to this clause: https://github.com/svanzoest-cookbooks/apache2/blob/master/definitions/apache_site.rb#L32 where line 22 is adding `.conf` to the filename.

This will be a breaking change due to the naming of the resource, and potential for duplicate virtual hosts.