### PR TITLE
Force service control block to trigger.

### DIFF
--- a/recipes/services.rb
+++ b/recipes/services.rb
@@ -3,6 +3,7 @@ if node['services']
     service k do
       action :nothing
     end
+
     ruby_block "service control (#{k})" do
       block do
         r = resources(:service => k)
@@ -12,6 +13,12 @@ if node['services']
       end
       subscribes :run, "service[#{k}]", :delayed
       action :nothing
+    end
+
+    log "service control (#{k})" do
+      message "config-driven-helper::services queueing actions [#{v.flatten.join(', ')}] for service #{k}"
+      level :debug
+      notifies :run, "ruby_block[service control (#{k})]", :delayed
     end
   end
 end

--- a/spec/recipes/services_spec.rb
+++ b/spec/recipes/services_spec.rb
@@ -1,0 +1,28 @@
+describe 'config-driven-helper::services' do
+  context 'with two services' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['services'] = {
+          'test1' => ['start', 'enable'],
+          'test2' => ['stop', 'disable']
+        }
+      end.converge(described_recipe)
+    end
+
+    it 'will start test1 via delayed notification' do
+      expect(chef_run.ruby_block('service control (test1)')).to subscribe_to('service[test1]').on(:run).delayed
+    end
+
+    it 'will start test2 via delayed notification' do
+      expect(chef_run.ruby_block('service control (test2)')).to subscribe_to('service[test2]').on(:run).delayed
+    end
+
+    it 'will ensure the test1 ruby block is triggered via a log message' do
+      expect(chef_run.log('service control (test1)')).to notify('ruby_block[service control (test1)]').to(:run).delayed
+    end
+
+    it 'will ensure the test2 ruby block is triggered via a log message' do
+      expect(chef_run.log('service control (test2)')).to notify('ruby_block[service control (test2)]').to(:run).delayed
+    end
+  end
+end


### PR DESCRIPTION
Say an existing service resource
```ruby
service 'test' do
  action :enable
end
```
and the desire is to get the service to enable and start via config-driven-helper::services.

If chef runs and 
```json
"services": {"test": ["enable","start"]}
```
is defined as configuration.
When the service is already enabled but not started, chef considers the service resource
as having nothing to do, so the previous iteration of this recipe would simply do nothing.

This was due to the ruby block only being triggered by the service having been updated
previously in the run.