### PR TITLE
Apache template name fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.0.0 (21 Jun 2016)
+
+NEW FEATURES:
+  * Apache 2.4 compatibility in the apache virtual host. Comprising of:
+    * #66 - Fix name of vhost template resource so the apache2 cookbook can enable the vhost
+    * #68 - Fix incompatible vhost configuration so that it works under apache 2.2 and 2.4
+
+BUG FIXES:
+    * #67 - Ubuntu compatibility for logs directory location
+
 ## 2.0.3 (23 May 2016)
 
 BUG FIXES:

--- a/definitions/app_vhost.rb
+++ b/definitions/app_vhost.rb
@@ -21,9 +21,10 @@ define :app_vhost, :server_type => nil, :site => {} do
 
     service_name = type == 'nginx' ? type : 'apache2'
     name = protocol == 'https' ? "#{params[:name]}.ssl" : params[:name]
-    name = "#{name}.conf" if type == 'apache' && node[type]['version'] == '2.4'
+    template_name = name
+    template_name = "#{template_name}.conf" if type == 'apache' && node[type]['version'] == '2.4'
 
-    template "#{node[type]['dir']}/sites-available/#{name}" do
+    template "#{node[type]['dir']}/sites-available/#{template_name}" do
       source site["template"]
       cookbook site["cookbook"]
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ issues_url        "https://github.com/inviqa/chef-config-driven-helper/issues"
 source_url        "https://github.com/inviqa/chef-config-driven-helper"
 license           "Apache 2.0"
 description       "enable driving cookbooks that are not normally config driven to be so"
-version           "2.0.4"
+version           "3.0.0"
 
 depends "apache2", ">= 1.8"
 depends 'iptables-ng', '>= 2.2'

--- a/spec/recipes/apache-sites_spec.rb
+++ b/spec/recipes/apache-sites_spec.rb
@@ -19,11 +19,13 @@ describe 'config-driven-helper::apache-sites' do
     end
 
     it 'will write out apache 2.2 configuration when 2.2 is in use' do
-      expect(chef_run).to render_file('/etc/apache2/sites-available/hello.example.com').with_content('Order allow,deny')
+      expect(chef_run).to render_file('/etc/apache2/sites-available/hello.example.com')
+        .with_content('Order allow,deny')
     end
 
     it 'will not write out apache 2.4 configuration when 2.2 is in use' do
-      expect(chef_run).to_not render_file('/etc/apache2/sites-available/hello.example.com').with_content('Require all granted')
+      expect(chef_run).to_not render_file('/etc/apache2/sites-available/hello.example.com')
+        .with_content('Require all granted')
     end
   end
 
@@ -37,15 +39,16 @@ describe 'config-driven-helper::apache-sites' do
     end
 
     it 'will write out a hello.example.com vhost' do
-      expect(chef_run).to create_template('/etc/apache2/sites-available/hello.example.com')
+      expect(chef_run).to create_template('/etc/apache2/sites-available/hello.example.com.conf')
     end
 
     it 'will write out apache 2.4 configuration when 2.4 is in use' do
-      expect(chef_run).to render_file('/etc/apache2/sites-available/hello.example.com').with_content('Require all granted')
+      expect(chef_run).to render_file('/etc/apache2/sites-available/hello.example.com.conf')
+        .with_content('Require all granted')
     end
 
     it 'will not write out apache 2.2 configuration when 2.4 is in use' do
-      expect(chef_run).to_not render_file('/etc/apache2/sites-available/hello.example.com').with_content('Order allow,deny')
+      expect(chef_run).to_not render_file('/etc/apache2/sites-available/hello.example.com.conf').with_content('Order allow,deny')
     end
   end
 end


### PR DESCRIPTION
The previous fix was unintentionally using the template name everywhere name used. This needed to be a separate variable