### PR TITLE
Fix issues with combinations of apache_site allow_from and basic_username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ NEW FEATURES:
 
 BUG FIXES:
     * #67 - Ubuntu compatibility for logs directory location
+    * #72 - Fix issues with combinations of apache_site allow_from and basic_username
 
 ## 2.0.3 (23 May 2016)
 

--- a/spec/recipes/apache-sites_spec.rb
+++ b/spec/recipes/apache-sites_spec.rb
@@ -11,6 +11,7 @@ describe 'config-driven-helper::apache-sites' do
         node.set['apache']['version'] = '2.2'
         node.set['apache']['sites']['hello.example.com']['docroot'] = '/var/www/hello.example.com'
         node.set['apache']['sites']['hello.example.com']['server_name'] = 'hello.example.com'
+        node.set['apache']['sites']['hello.example.com']['allow_from'] = ['127.0.0.1']
       end.converge(described_recipe)
     end
 
@@ -20,12 +21,12 @@ describe 'config-driven-helper::apache-sites' do
 
     it 'will write out apache 2.2 configuration when 2.2 is in use' do
       expect(chef_run).to render_file('/etc/apache2/sites-available/hello.example.com')
-        .with_content('Order allow,deny')
+        .with_content('Allow from 127.0.0.1')
     end
 
     it 'will not write out apache 2.4 configuration when 2.2 is in use' do
       expect(chef_run).to_not render_file('/etc/apache2/sites-available/hello.example.com')
-        .with_content('Require all granted')
+        .with_content('Require ip 127.0.0.1')
     end
   end
 
@@ -35,6 +36,7 @@ describe 'config-driven-helper::apache-sites' do
         node.set['apache']['version'] = '2.4'
         node.set['apache']['sites']['hello.example.com']['docroot'] = '/var/www/hello.example.com'
         node.set['apache']['sites']['hello.example.com']['server_name'] = 'hello.example.com'
+        node.set['apache']['sites']['hello.example.com']['allow_from'] = ['127.0.0.1']
       end.converge(described_recipe)
     end
 
@@ -44,11 +46,12 @@ describe 'config-driven-helper::apache-sites' do
 
     it 'will write out apache 2.4 configuration when 2.4 is in use' do
       expect(chef_run).to render_file('/etc/apache2/sites-available/hello.example.com.conf')
-        .with_content('Require all granted')
+        .with_content('Require ip 127.0.0.1')
     end
 
     it 'will not write out apache 2.2 configuration when 2.4 is in use' do
-      expect(chef_run).to_not render_file('/etc/apache2/sites-available/hello.example.com.conf').with_content('Order allow,deny')
+      expect(chef_run).to_not render_file('/etc/apache2/sites-available/hello.example.com.conf')
+        .with_content('Allow from 127.0.0.1')
     end
   end
 end

--- a/templates/default/apache_site.conf.erb
+++ b/templates/default/apache_site.conf.erb
@@ -47,7 +47,7 @@
     EnableSendfile <%= @params['enable_sendfile'] || 'On' %>
 
 <% if @params['basic_username'] %>
-    <%= "Satisfy Any" if @params['allow_from'] && @type['version'] == '2.2' %>
+    <%= "Satisfy Any" if @type['version'] == '2.2' %>
     AuthUserFile <%= @params['docroot'] %>/.htpasswd
     AuthType Basic
     AuthName "Protected System"
@@ -64,11 +64,10 @@
     AllowOverride <%= @params['parse_htaccess'] ? "All" : "None" %>
 
 <% if @type['version'] == '2.2' %>
-    Order allow,deny
-    <%= @params['allow_from'] ? @params['allow_from'].map { |ip| "    Allow from #{ip}\n" }.join("\n") : "    Allow from all" %>
+    <%= @params['allow_from'] ? @params['allow_from'].map { |ip| "    Allow from #{ip}\n" }.join("\n") : "" %>
+    <%= 'Order allow,deny' if @params['allow_from'] || @params['basic_username'] %>
 <% else %>
     <%= @params['allow_from'] ? @params['allow_from'].map { |ip| "    Require ip #{ip}" }.join("\n") : '' %>
-    <%= !@params['allow_from'] && !@params['basic_username'] ? "    Require all granted" : "" %>
 <% end %>
 
     DirectoryIndex index.php

--- a/templates/default/apache_site.conf.erb
+++ b/templates/default/apache_site.conf.erb
@@ -65,7 +65,7 @@
 
 <% if @type['version'] == '2.2' %>
     Order allow,deny
-    <%= @params['allow_from'] ? @params['allow_from'].map { |ip| "    Allow from #{ip}\n" } : "    Allow from all" %>
+    <%= @params['allow_from'] ? @params['allow_from'].map { |ip| "    Allow from #{ip}\n" }.join("\n") : "    Allow from all" %>
 <% else %>
     <%= @params['allow_from'] ? @params['allow_from'].map { |ip| "    Require ip #{ip}" }.join("\n") : '' %>
     <%= !@params['allow_from'] && !@params['basic_username'] ? "    Require all granted" : "" %>


### PR DESCRIPTION
* Fix issue with rendering of apache_site allow_from in Apache Httpd 2.2
* Fix issue with apache_site basic_username when no allow_from in 2.2
* Simplify directive usage (removing explicit config already implied by default)