### PR TITLE
Reverse <Directory /> deny in Httpd 2.4 if no restrictions

### DIFF
--- a/templates/default/apache_site.conf.erb
+++ b/templates/default/apache_site.conf.erb
@@ -70,6 +70,7 @@
     <%= 'Order allow,deny' if @params['allow_from'] || @params['http_auth']['type'] != 'none' %>
 <% else %>
     <%= @params['allow_from'] ? @params['allow_from'].map { |ip| "    Require ip #{ip}" }.join("\n") : '' %>
+    <%= 'Require all granted' unless @params['allow_from'] || @params['http_auth']['type'] != 'none' %>
 <% end %>
 
     DirectoryIndex index.php


### PR DESCRIPTION
Httpd 2.4 default configuration does

<Directory />
Require all denied
</Directory>

Vhosts have to reverse this if they are to allow unrestricted access.