### PR TITLE
Fix issue in icmp ip6tables rule

### DIFF
--- a/recipes/iptables-standard.rb
+++ b/recipes/iptables-standard.rb
@@ -12,9 +12,25 @@ iptables_ng_rule '10-local' do
   rule '--in-interface lo --jump ACCEPT'
 end
 
-iptables_ng_rule '10-icmp' do
+# cleanup old versions of the rule
+iptables_ng_rule "10-icmp" do
   chain 'STANDARD-FIREWALL'
-  rule '--protocol icmp --jump ACCEPT'
+  action :delete
+end
+
+node['iptables-ng']['enabled_ip_versions'].each do |version|
+  case version
+  when 6
+    icmp = 'ipv6-icmp'
+  else
+    icmp = 'icmp'
+  end
+
+  iptables_ng_rule "10-icmp-ipv#{version}" do
+    chain 'STANDARD-FIREWALL'
+    rule "--protocol #{icmp} --jump ACCEPT"
+    ip_version version.to_i
+  end
 end
 
 node['iptables-standard']['allowed_incoming_ports'].each do |rule, port|

--- a/spec/recipes/iptables-standard_spec.rb
+++ b/spec/recipes/iptables-standard_spec.rb
@@ -14,6 +14,19 @@ describe 'config-driven-helper::iptables-standard' do
         )
       end
     end
+
+    it "creates separate entries for ipv4 and ipv6 icmp allow" do
+      expect(chef_run).to create_iptables_ng_rule("10-icmp-ipv4").with(
+        chain: 'STANDARD-FIREWALL',
+        rule: '--protocol icmp --jump ACCEPT',
+        ip_version: 4
+      )
+      expect(chef_run).to create_iptables_ng_rule("10-icmp-ipv6").with(
+        chain: 'STANDARD-FIREWALL',
+        rule: '--protocol ipv6-icmp --jump ACCEPT',
+        ip_version: 6
+      )
+    end
   end
   
   context 'with additonal config' do


### PR DESCRIPTION
The protocol name has changed in ipv6. ICMP is also needed for ipv6 TCP to work as well