### PR TITLE
add support for Nginx http_realip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.7.0 (04 Apr 2016)
+
+NEW FEATURES:
+
+  * #91 Add support for Nginx http_realip
+
 ## 2.6.1 (06 Oct 2016)
 
 BUG FIXES:

--- a/README.md
+++ b/README.md
@@ -197,6 +197,33 @@ Add `config-driven-helper::nginx-sites` to enable it.
 
 ```
 
+#### http_realip
+eable nginx_http_realip module to be used in conjunction with HTTP_AUTH
+to be able to match the real ip of a visitor even if it comes
+from a Proxied connection (i.e. Varis, CloudFlare, others)
+
+It can be used togheter with Inviqa's cookbook [cloudflare-ips](https://github.com/inviqa/chef-cloudflare-ips)
+
+Default values:
+```
+default['nginx']['real_ip_header'] = "X-Forwarded-For"
+default['nginx']['real_ip_from'] = []
+default['nginx']['real_ip_recursive'] = "on"
+```
+
+Add `config-driven-helper::nginx-http-realip` to enable it.
+```json
+{
+  "nginx": {
+    "real_ip_from": [
+      "1.2.3.4",
+      "5.6.7.8"
+    ]
+  }
+}
+
+```
+
 ### Mysql users
 
 The mysql users helper enables you to create mysql users from attributes. It proxies the attributes to the `mysql_database_user` resource defined by the `database` cookbook here: https://github.com/opscode-cookbooks/database#database_user. This means that any attributes valid there are valid here.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,6 +5,9 @@ default['ssl_certs'] = {}
 default['packages-additional'] = {}
 
 default['nginx']['https_variable_emulation'] = false
+default['nginx']['real_ip_header'] = "X-Forwarded-For"
+default['nginx']['real_ip_from'] = [] 
+default['nginx']['real_ip_recursive'] = "On"
 
 protocols = {
   'nginx' => 'TLSv1 TLSv1.1 TLSv1.2',

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ issues_url        "https://github.com/inviqa/chef-config-driven-helper/issues"
 source_url        "https://github.com/inviqa/chef-config-driven-helper"
 license           "Apache 2.0"
 description       "enable driving cookbooks that are not normally config driven to be so"
-version           "2.6.1"
+version           "2.7.0"
 
 depends "apache2", ">= 1.8"
 depends 'iptables-ng', '>= 2.2'

--- a/recipes/nginx-http-realip.rb
+++ b/recipes/nginx-http-realip.rb
@@ -1,0 +1,12 @@
+template "#{node['nginx']['dir']}/conf.d/http_realip.conf" do
+  source 'http_realip.conf.erb'
+  owner  'root'
+  group  'root'
+  mode   '0644'
+  variables({
+    :real_ip_from => node['nginx']['real_ip_from'],
+    :real_ip_header => node['nginx']['real_ip_header'],
+    :real_ip_recursive => node['nginx']['real_ip_recursive']
+  })
+  notifies :reload, 'service[nginx]'
+end

--- a/templates/default/http_realip.conf.erb
+++ b/templates/default/http_realip.conf.erb
@@ -1,0 +1,15 @@
+# This config file enables http_realip module
+# some `set_real_ip_from` can be set here
+# other can be contained in separate files i.e. `cloudflare-ips`
+#
+# set_real_ip_from x.x.x.x/xx;
+# set_real_ip_from 0000:0000::/xx;
+
+<%- if @real_ip_from -%>
+    <%- @real_ip_from.each do |ip_address| %>
+set_real_ip_from <%= ip_address %>;
+    <%- end -%>
+<%- end %>
+
+real_ip_header <%= @real_ip_header %>;
+real_ip_recursive <%= @real_ip_recursive %>;


### PR DESCRIPTION
creates the file `nginx/conf.d/http_realip.conf`
accept an array of IPs (IPv4 and IPv6) to be listed as `set_ real_ip_from`