### PR TITLE
Add http2 support for NGINX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 CHANGES:
 
-  * #88 Optionally set the HTTPS environment variable to "on" if X-Forwarded-Proto is "https" in NGINX
+  * #88 Optionally set the HTTPS environment variable to "on" if X-Forwarded-Proto is "https"
   * #94 Support HTTP2 in NGINX
 
 ## 3.0.0 (21 Feb 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.1.0 (17 Aug 2018)
+
+CHANGES:
+
+  * #88 Optionally set the HTTPS environment variable to "on" if X-Forwarded-Proto is "https" in NGINX
+  * #94 Support HTTP2 in NGINX
+
 ## 3.0.0 (21 Feb 2018)
 
 CHANGES:

--- a/README.md
+++ b/README.md
@@ -198,11 +198,11 @@ Add `config-driven-helper::nginx-sites` to enable it.
 ```
 
 #### http_realip
-eable nginx_http_realip module to be used in conjunction with HTTP_AUTH
+Enable nginx_http_realip module to be used in conjunction with HTTP_AUTH
 to be able to match the real ip of a visitor even if it comes
 from a Proxied connection (i.e. Varis, CloudFlare, others)
 
-It can be used togheter with Inviqa's cookbook [cloudflare-ips](https://github.com/inviqa/chef-cloudflare-ips)
+It can be used together with Inviqa's cookbook [cloudflare-ips](https://github.com/inviqa/chef-cloudflare-ips)
 
 Default values:
 ```
@@ -223,6 +223,29 @@ Add `config-driven-helper::nginx-http-realip` to enable it.
 }
 
 ```
+
+#### HTTP2
+Support HTTP2 in Nginx by adding "http2" to the end of the listen line.
+
+You can enable this by adding `enable_http2_tls` to your site definition like so:
+```json
+{
+  "nginx": {
+    "sites": {
+      "inviqa": {
+        "server_name": "inviqa.com",
+        "docroot": "/var/www/inviqa.com",
+        "protocols": [ "http", "https" ],
+        "keyfile": "/tmp/my-super-insecure-keyfile.pem"
+        "enable_http2_tls": true
+      }
+    }
+  }
+}
+```
+
+`enable_http2_plaintext_disabling_http1` is also available to enable
+http2 on the insecure port, however as Nginx doesn't support h2c for plain HTTP protocol so will not support HTTP 1.1/1.0 if enabled.
 
 ### Mysql users
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,6 +49,8 @@ protocols = {
   site['template'] = "#{type}_site.conf.erb"
   site['cookbook'] = 'config-driven-helper'
   site['protocols'] = ['http']
+  site['enable_http2_tls'] = false
+  site['enable_http2_plaintext'] = false
   site['server_type'] = type
   site['disable_default_location_block'] = false
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -51,7 +51,7 @@ protocols = {
   site['protocols'] = ['http']
   site['forwarded_proto_https_emulation'] = false
   site['enable_http2_tls'] = false
-  site['enable_http2_plaintext'] = false
+  site['enable_http2_plaintext_disabling_http1'] = false
   site['server_type'] = type
   site['disable_default_location_block'] = false
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,6 +49,7 @@ protocols = {
   site['template'] = "#{type}_site.conf.erb"
   site['cookbook'] = 'config-driven-helper'
   site['protocols'] = ['http']
+  site['forwarded_proto_https_emulation'] = false
   site['enable_http2_tls'] = false
   site['enable_http2_plaintext'] = false
   site['server_type'] = type

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ issues_url        "https://github.com/inviqa/chef-config-driven-helper/issues"
 source_url        "https://github.com/inviqa/chef-config-driven-helper"
 license           "Apache 2.0"
 description       "enable driving cookbooks that are not normally config driven to be so"
-version           "3.0.0"
+version           "3.1.0"
 
 depends "apache2", ">= 1.8"
 depends 'iptables-ng', '>= 2.2'

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -2,7 +2,7 @@ server {
     <% if @protocol == 'https' %>
     listen <%= @params['secure_port'] %> ssl<% if @params['enable_http2_tls'] %> http2<% end %>;
     <% else %>
-    listen <%= @params['insecure_port'] %><% if @params['enable_http2_plaintext'] %> http2<% end %>;
+    listen <%= @params['insecure_port'] %><% if @params['enable_http2_plaintext_disabling_http1'] %> http2<% end %>;
     <% end %>
 
     root <%= @params['docroot']%>;

--- a/templates/default/nginx_site.conf.erb
+++ b/templates/default/nginx_site.conf.erb
@@ -1,8 +1,8 @@
 server {
     <% if @protocol == 'https' %>
-    listen <%= @params['secure_port'] %> ssl;
+    listen <%= @params['secure_port'] %> ssl<% if @params['enable_http2_tls'] %> http2<% end %>;
     <% else %>
-    listen <%= @params['insecure_port'] %>;
+    listen <%= @params['insecure_port'] %><% if @params['enable_http2_plaintext'] %> http2<% end %>;
     <% end %>
 
     root <%= @params['docroot']%>;


### PR DESCRIPTION
Based on https://github.com/continuouspipe/dockerfiles/blob/ac0eac9a39cd4eb95927fb99b29a2fdb2dfbdf1d/php/nginx/etc/confd/templates/nginx/site.conf.tmpl